### PR TITLE
modules: Replace disable with enable flag

### DIFF
--- a/example-config.nix
+++ b/example-config.nix
@@ -9,12 +9,14 @@ in
 {
   configs = {
     treesitter = {
+      enable = true;
       treesitter.parsers = { inherit (parsers) nix; };
       plugins = [ pkgs.vimPlugins.nvim-treesitter ];
       setup.modulePath = "nvim-treesitter.configs";
       setup.args.highlight.enable = true;
     };
     telescope = {
+      enable = true;
       plugins = with pkgs.vimPlugins; [ telescope-nvim plenary-nvim popup-nvim ];
       setup.args = { };
       keymaps = map (nix2nvimrc.toKeymap { silent = true; }) [
@@ -24,6 +26,7 @@ in
       ];
     };
     lspconfig = {
+      enable = true;
       after = [ "telescope" ];
       plugins = [ pkgs.vimPlugins.nvim-lspconfig ];
       lspconfig.servers = lib.optionalAttrs
@@ -31,7 +34,7 @@ in
         { rnix.pkg = pkgs.rnix-lsp; };
       vim = [ ./test/init.vim ];
     };
-    empty_notused.disable = true;
+    empty_notused.enable = false;
     empty_used = { };
   };
 }

--- a/module.nix
+++ b/module.nix
@@ -52,10 +52,10 @@ let
 
   configType = types.submodule {
     options = {
-      disable = mkOption {
+      enable = mkOption {
         type = types.bool;
         default = false;
-        description = "Disable configuration";
+        description = "Enable module";
       };
       after = mkOption {
         type = types.listOf types.str;
@@ -176,7 +176,7 @@ in
             (map
               (name: config.configs.${name} // { inherit name; })
               (builtins.filter
-                (name: !config.configs.${name}.disable)
+                (name: config.configs.${name}.enable)
                 (builtins.attrNames config.configs)));
         in
           res.result or (throw "Config has a cyclic dependency");


### PR DESCRIPTION
Make modules behave more like nixos modules and require users to enable a configuration / module. The default should be false, so we can cascade module imports over many flakes, similar to flake nixosModules.